### PR TITLE
Fix ncu_parser for different csv column count

### DIFF
--- a/report_parser/ncu_parser.py
+++ b/report_parser/ncu_parser.py
@@ -127,6 +127,7 @@ class NcuParser:
         self._metric_dict = defaultdict(lambda: defaultdict(lambda: float))
 
         parse_metric = False
+        metric_cnt = 0
 
         for line in out.split("\n"):
             line = line.strip(",").strip('"').split('","')
@@ -142,8 +143,9 @@ class NcuParser:
                     self._fn_to_idx[fn] = idx
 
                 parse_metric = True
+                metric_cnt = len(line)
             else:
-                if len(line) != 12:
+                if len(line) != metric_cnt:
                     continue
                 kernel_name = line[self._fn_to_idx["Kernel Name"]]
                 metric_name = line[self._fn_to_idx["Metric Name"]]


### PR DESCRIPTION
## My Environment
* ncu (Version 2023.1.0.0)
* nvcc (release 12.1, V12.1.66)
* driver version: 530.30.02
* hardware: NVIDIA A10

## Bug report
When the original `ncu_parser.py` parses the output CSV file generated by ncu, it asserts the number of metrics of each row is 12. While in my setting it is 15, it skips all the lines.
https://github.com/jiashenC/gpudb-char-and-opt/blob/0395d20abdc50ae07f3d90e9dc4ddc18c2759e29/report_parser/ncu_parser.py#L146-L147

## Fix
While the number of metrics may differs in different ncu versions, a flexible way may be filtering the invalid row according to the actual metric number achieved from the first row.